### PR TITLE
[FIX] Avoid Invalid User Exception when entering direct chat while not authenticated #21735

### DIFF
--- a/app/ui-utils/client/lib/openRoom.js
+++ b/app/ui-utils/client/lib/openRoom.js
@@ -101,14 +101,14 @@ export const openRoom = async function(type, name, render = true) {
 			return callbacks.run('enter-room', sub);
 		} catch (error) {
 			c.stop();
-			if (type === 'd') {
+			if (type === 'd' && error.error !== 'error-invalid-user') {
 				const result = await call('createDirectMessage', ...name.split(', '));
 				if (result) {
 					return FlowRouter.go('direct', { rid: result.rid }, FlowRouter.current().queryParams);
 				}
 			}
 			Session.set('roomNotFound', { type, name, error });
-			return appLayout.render('main', { center: 'roomNotFound' });
+			appLayout.render('main', { center: 'loading' });
 		}
 	});
 };


### PR DESCRIPTION
Solves errors being shown to user when creating direct chat by directly navigating to URL #21735

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
Avoid "Invalid User Exception" and "No user with username..." being displayed to user as shown in this embedded gif when entering direct chat with no session present: 
![image](https://user-images.githubusercontent.com/15807436/126312663-aa5e9ec9-8b6c-4892-93fa-e381f1c48157.png)

## Issue(s)
#21735

## Steps to test or reproduce fix
1. Use iframe authentication (not sure this is a must)
2. Directly navigate to a URL like /direct/W5xxxxxxxxQD?layout=embedded (W5xxxxxxxxQD is the room id of an existing room) -OR- (Variant B) Directly navigate to a URL /direct/Christof_Teng?layout=embedded where Christof_Teng is a username
2. Red error notification "Invalid User" is no longer displayed
3.  "No user with username "W5xxxxxxxxQD" was found! is no longer briefly shown" -OR- (Variant B) "No user with username "Christof_Teng" was found!" is no longer briefly shown
4. The chatroom loads
5. search for getRoomByTypeAndName in javascript console. You will find that there are 2 calls, the first one fails, but the error caused by the first call is no longer shown to user.


## Further comments
The video above shows the myriad of errors that were displayed to the user when loading a direct chat when using iframe authentication. This fix shows the loading screen until successful render of the direct chat.
